### PR TITLE
Add minimal checkIntersection polyfill for Firefox

### DIFF
--- a/context-atlas/index.ts
+++ b/context-atlas/index.ts
@@ -90,6 +90,7 @@ export class BertVis {
     await this.loadWords();
     const urlWord = util.getURLWord();
     this.getData(urlWord ? urlWord : 'lie');
+    util.polyfillCheckIntersection();
   }
 
   private addHandlers() {

--- a/context-atlas/util.ts
+++ b/context-atlas/util.ts
@@ -229,3 +229,24 @@ export function setURLWord(word: string) {
 export function isMobile() {
   return screen.width <= 590;
 }
+
+// Minimal poylfill, for more on browser support see:
+// https://bugs.chromium.org/p/chromium/issues/detail?id=370012
+// https://bugzilla.mozilla.org/show_bug.cgi?id=501421
+// https://bugzilla.mozilla.org/show_bug.cgi?id=501421
+function checkIntersectionPolyfill(node, otherBox) {
+  const nodeBox = node.getBBox();
+  return !(
+    (nodeBox.left > otherBox.right) || 
+    (nodeBox.right < otherBox.left) || 
+    (nodeBox.top > otherBox.bottom) ||
+    (nodeBox.bottom < otherBox.top)
+  );
+}
+
+// Add the polyfill
+export function polyfillCheckIntersection() {
+  if (!SVGSVGElement.prototype.checkIntersection) {
+    SVGSVGElement.prototype.checkIntersection = checkIntersectionPolyfill;
+  }
+}


### PR DESCRIPTION
Thanks for sharing this awesome work! 😄 

I tried this out on Firefox and noticed that the zooming and panning didn't work; the labels might not translate, or they drift away from the points.  Here's an example:
<img width="692" alt="Screen Shot 2019-08-15 at 3 54 20 PM" src="https://user-images.githubusercontent.com/1056957/63122555-0bb4fc00-bf75-11e9-910a-87b6bf9b5553.png">

On the console I saw this:
<img width="1180" alt="Screen Shot 2019-08-15 at 3 18 05 PM" src="https://user-images.githubusercontent.com/1056957/63122247-38b4df00-bf74-11e9-9417-34090812c440.png">

Reading around, it seems like `SVGElement#checkIntersection` isn't implemented in Firefox, and I didn't find a proper polyfill looking for a minute.  But this minimal bit works if I paste it on the console:
```
if (!SVGSVGElement.prototype.checkIntersection) {
  SVGSVGElement.prototype.checkIntersection = function(node, otherBox) {
    const nodeBox = node.getBBox();
    return !(
      (nodeBox.left > otherBox.right) || 
      (nodeBox.right < otherBox.left) || 
      (nodeBox.top > otherBox.bottom) ||
      (nodeBox.bottom < otherBox.top)
    );
  }
}
```

So I tried to adapt that into the codebase here so this works across browsers, which I hope is helpful, although maybe there's a better way to do this that fits the project style better, or a better way to polyfill this more thoroughly, I'm not sure.

Thanks again for sharing such interesting work! 👍 