### PR TITLE
Update script for statics/json folder in local dev

### DIFF
--- a/context-atlas/.gitignore
+++ b/context-atlas/.gitignore
@@ -1,0 +1,3 @@
+.cache
+static
+node_modules

--- a/context-atlas/download_pregenerated_jsons.sh
+++ b/context-atlas/download_pregenerated_jsons.sh
@@ -20,5 +20,5 @@
 # This script downloads the pre-generated jsons from the google cloud bucket.
 
 echo "Downloading..."
-mkdir static
+mkdir -p static/jsons
 gsutil -m cp gs://bert-wsd-vis/demo/jsons/* static/jsons


### PR DESCRIPTION
I was trying to verify that https://github.com/PAIR-code/interpretability/pull/5 worked by running the project, but got a bunch of errors running the `download_pregenerated_jsons.sh` script:

```
CommandException: Destination URL must name a directory, bucket, or bucket
subdirectory for the multiple source form of the cp command.
CommandException: Destination URL must name a directory, bucket, or bucket
subdirectory for the multiple source form of the cp command.
...
```

This adds a mkdir for `static/jsons` which then lets the download command start copying all those files down :)

I also added a gitignore with data and build artifacts for things I figured weren't supposed to be checked in, but are created in the local dev process.

Thanks again for sharing this work in the open! 😄 