### PR TITLE
Patch checkIntersection polyfill, include more labels

### DIFF
--- a/context-atlas/index.ts
+++ b/context-atlas/index.ts
@@ -325,14 +325,19 @@ export class BertVis {
 
       // Check whether this new box intersects with anything.
       let intersects = false;
-      renderedWordBboxes.forEach((bbox) => {
+      for (let j = 0; j < renderedWordBboxes.length; j++) {
+        const bbox = renderedWordBboxes[j];
         const intersectsThisBox =
             (svgNode.checkIntersection(text.node(), bbox));
         intersects = intersects || intersectsThisBox;
+        if (intersects) {
+          break;
+        }
       });
-      renderedWordBboxes.push(text.node().getBBox());
       if (intersects) {
         text.remove();
+      } else {
+        renderedWordBboxes.push(text.node().getBBox());
       }
       d.visible = !intersects;
     }

--- a/context-atlas/util.ts
+++ b/context-atlas/util.ts
@@ -237,10 +237,10 @@ export function isMobile() {
 function checkIntersectionPolyfill(node, otherBox) {
   const nodeBox = node.getBBox();
   return !(
-    (nodeBox.left > otherBox.right) || 
-    (nodeBox.right < otherBox.left) || 
-    (nodeBox.top > otherBox.bottom) ||
-    (nodeBox.bottom < otherBox.top)
+    (nodeBox.x > (otherBox.x + otherBox.width)) || 
+    ((nodeBox.x + nodeBox.width) < otherBox.x) || 
+    (nodeBox.y > (otherBox.y + otherBox.height)) ||
+    ((nodeBox.y + nodeBox.height) < otherBox.y)
   );
 }
 


### PR DESCRIPTION
Addresses https://github.com/PAIR-code/interpretability/issues/10, since https://github.com/PAIR-code/interpretability/pull/5 patched the most serious problem by adding a method so the rest of the code could still run, but that method was calculating wrong - `getBBox()` returns `{x,y,width,height}` `not {left,right,top,bottom}`. :)

Separately, this updates the intersection check to skip what seem like some redundant checks that prevent a few labels from being drawn.  It would essentially include in `renderedWordBboxes` the dimensions of labels that it checked and intersected, but didn't actually draw.  So in this scenario...

<img width="409" alt="Screen Shot 2019-08-22 at 12 22 04 PM" src="https://user-images.githubusercontent.com/1056957/63531947-a2cf0600-c4d7-11e9-8a37-a0cb886c1dcf.png">

....what happens is that (1) gets drawn first, (2) isn't drawn since it intersects but it gets added to `renderedWordBboxes` anyway and then (3) doesn't get drawn since it intersects with where 2 would have been.  This came up in trying to see what was happening in the bug in https://github.com/PAIR-code/interpretability/issues/10, but of course feel free to remove that bit if you all think this change isn't helpful.  The diff is that (3) is now drawn, and you can see some screenshots below.

There are some minor changes across browsers but maybe I'm not resizing exactly right or the font sizing is subtly different, not sure.  This seemed good enough to 🚢 to me!

### master, firefox
![image](https://user-images.githubusercontent.com/1056957/63531675-099fef80-c4d7-11e9-8906-5b68d18daae7.png)

### this PR, firefox (labels)
![image](https://user-images.githubusercontent.com/1056957/63531706-191f3880-c4d7-11e9-889f-b3d5989665f8.png)


### master, chrome
![image](https://user-images.githubusercontent.com/1056957/63531688-0efd3a00-c4d7-11e9-8816-e8192ae025e2.png)

### master, chrome (a few more labels)
![image](https://user-images.githubusercontent.com/1056957/63531731-25a39100-c4d7-11e9-902f-947e8ed20fc0.png)

